### PR TITLE
fix problem :dotenv to deploy with render

### DIFF
--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -4,7 +4,9 @@ use Symfony\Component\Dotenv\Dotenv;
 
 require dirname(__DIR__).'/vendor/autoload.php';
 
-if (method_exists(Dotenv::class, 'bootEnv')) {
+if (file_exists(dirname(__DIR__).'/config/bootstrap.php')) {
+    require dirname(__DIR__).'/config/bootstrap.php';
+} elseif (method_exists(Dotenv::class, 'bootEnv')) {
     (new Dotenv())->bootEnv(dirname(__DIR__).'/.env');
 }
 


### PR DESCRIPTION
I try to fix the problem :
Fatal error: Uncaught Symfony\Component\Dotenv\Exception\PathException: Unable to read the "/var/www/html/.env" environment file. in /var/www/html/vendor/symfony/dotenv/Dotenv.php:552 Stack trace: #0 

I mofify the file tests/bottstrap.php -> I want that the file .env is ignored